### PR TITLE
switch to onResponseStarted

### DIFF
--- a/background.js
+++ b/background.js
@@ -168,7 +168,7 @@ function handleConnect(port) {
     });
 }
 
-browser.webRequest.onHeadersReceived.addListener(
+browser.webRequest.onResponseStarted.addListener(
     cfdetect,
     { urls: [ "<all_urls>" ] },
     [ "responseHeaders" ]


### PR DESCRIPTION
`onHeadersReceived` is not necessary for this extension, and is ~~likely to clash with something sooner or later. It also has some issues of its own (see `https://github.com/ghacksuserjs/ghacks-user.js/issues/265`).~~ (Edit: actually, it seems to be safe as long as we don't **modify** headers, but switching to OnResponseStarted would still help in other ways, for example the count of requests would be more accurate). 

Additionally, it may be a coincidence, but with [onResponseStarted ](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onResponseStarted)I haven't been able to reproduce #8 so far.