### PR TITLE
Update Cloudflare HTTP server header string

### DIFF
--- a/background.js
+++ b/background.js
@@ -114,7 +114,7 @@ function cfdetect( details ) {
         var h = headers[i];
         var hname = h.name.toLowerCase();
         if ((hname === "cf-ray") ||
-            (hname === "server" && h.value === "cloudflare-nginx")) {
+            (hname === "server" && h.value === "cloudflare")) {
             cf = true;
             break;
         }


### PR DESCRIPTION
The HTTP server header was changed to `cloudflare` instead of `cloudflare-nginx` since Jan 2018.

Reference:

- https://blog.cloudflare.com/end-of-the-road-for-cloudflare-nginx/